### PR TITLE
[sync] add root pkg sync and rc-release support

### DIFF
--- a/cli-actions.js
+++ b/cli-actions.js
@@ -1,7 +1,7 @@
 const chalk = require('chalk');
 const { inc } = require('./lib/util');
 const semver = require('semver');
-const { buildGraph, targetUpdate, identifyOutOfSync, commit } = require('./index');
+const { buildGraph, targetUpdate, identifyOutOfSync, commit, checkRootPackage } = require('./index');
 const { confirm, checkbox, text, select, number, password } = require('./lib/inputs');
 const { inverseDependencyGraph } = require('./lib/pkg');
 
@@ -108,6 +108,15 @@ module.exports = function getHandlers () {
         ])
 
         if (nextAction === 'Accept all changes') {
+          const { outOfSync, updateRootPackage } = checkRootPackage(connections)
+
+          if (outOfSync) {
+            const updateRoot = await confirm('The monorepo root package.json looks like it might be out of date. Would you like to upgrade dependencies?', true)
+            if (updateRoot) {
+              updateRootPackage()
+            }
+          }
+
           commit(connections)
           userLoop = 'done'
         }

--- a/lib/util.js
+++ b/lib/util.js
@@ -41,7 +41,7 @@ function diff (version1, version2) {
   const diff = semver.diff(version1, version2)
   if (!diff) return diff
 
-  if (diff === 'prerelease' && semver.lt(version1, version2)) {
+  if (diff === 'prerelease' && semver.lt(version1, version2) && semver.parse(version2).prerelease.length === 0) {
     return 'major'
   }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -40,6 +40,11 @@ function inc (version, type) {
 function diff (version1, version2) {
   const diff = semver.diff(version1, version2)
   if (!diff) return diff
+
+  if (diff === 'prerelease' && semver.lt(version1, version2)) {
+    return 'major'
+  }
+
   const v2 = semver.parse(version2);
   if (v2.major === 0) {
     let zeroVersion = diff

--- a/lib/util.test.js
+++ b/lib/util.test.js
@@ -40,6 +40,13 @@ diffTests = [
 describe('diff', () => {
   diffTests.forEach(([ v1, v2, expected ]) => {
     it(`${v1} --> ${v2} : ${expected}`, () => expect(diff(v1, v2)).toEqual(expected));
+  });
+
+  [
+    [ '0.1.0-alpha.0', '0.1.0', 'major' ],
+    [ '0.1.1-beta.1',  '0.1.1', 'major' ],
+  ].forEach(([ v1, v2, expected ]) => {
+    it(`${v1} --> ${v2} : ${expected}`, () => expect(diff(v1, v2)).toEqual(expected));
   })
 })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pkgpig",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Manage semantic versioning in a monorepo context.",
   "main": "cli.js",
   "repository": "https://github.com/kyle-west/pkgpig",


### PR DESCRIPTION
Fixes #3 

These changes make add an option to upgrade the root package file when committing changes. It also allows for us to move from `2.0.0-rc.0` to a full release (`2.0.0`).