### PR TITLE
[sync] fix problems moving from rc to full release

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,9 @@ function compareGT (target, current) {
   if (target.includes('prerelease')) {
     return !current
   }
+  if (target === 'release') {
+    return !current
+  }
   return false
 }
 
@@ -114,6 +117,12 @@ function commit (graph) {
   })
 }
 
+function summarize (graph) {
+  return Object.entries(graph).map(([name, { version: { original, pending } }]) =>
+    ({ Package: name, PendingVersion: pending, OriginalVersion: original, Changed: original !== pending })
+  ).sort((a, b) => a.Package.localeCompare(b.Package))
+}
+
 function checkRootPackage (graph) {
   const rootPkg = getRootPkg()
   debugger
@@ -161,4 +170,5 @@ module.exports = {
   targetUpdate,
   commit,
   checkRootPackage,
+  summarize,
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,6 +4,11 @@ const semver = require('semver');
 function inc (version, type) {
   let [ baseType, prerelease ] = type.split('-');
 
+  if (type === 'release') {
+    const { major, minor, patch } = semver.parse(version)
+    return `${major}.${minor}.${patch}`
+  }
+
   if (baseType === 'prerelease') {
     if (prerelease.startsWith('pre') && version.startsWith('0')) {
       const releaseType = prerelease.substring(3)
@@ -41,8 +46,9 @@ function diff (version1, version2) {
   const diff = semver.diff(version1, version2)
   if (!diff) return diff
 
+  // moving from a pre-release to a full-qualified release
   if (diff === 'prerelease' && semver.lt(version1, version2) && semver.parse(version2).prerelease.length === 0) {
-    return 'major'
+    return 'release'
   }
 
   const v2 = semver.parse(version2);

--- a/lib/util.test.js
+++ b/lib/util.test.js
@@ -35,19 +35,15 @@ diffTests = [
 
   [ '0.1.0-alpha.0', '0.1.0-alpha.1', 'prerelease-prealpha' ],
   [ '0.1.1-alpha.0', '0.1.1-alpha.1', 'prerelease-prealpha' ],
+
+  [ '0.1.0-alpha.0', '0.1.0', 'release' ],
+  [ '0.1.1-beta.1',  '0.1.1', 'release' ],
 ]
 
 describe('diff', () => {
   diffTests.forEach(([ v1, v2, expected ]) => {
     it(`${v1} --> ${v2} : ${expected}`, () => expect(diff(v1, v2)).toEqual(expected));
   });
-
-  [
-    [ '0.1.0-alpha.0', '0.1.0', 'major' ],
-    [ '0.1.1-beta.1',  '0.1.1', 'major' ],
-  ].forEach(([ v1, v2, expected ]) => {
-    it(`${v1} --> ${v2} : ${expected}`, () => expect(diff(v1, v2)).toEqual(expected));
-  })
 })
 
 // inc should be 1:1 compatible with diff

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pkgpig",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Manage semantic versioning in a monorepo context.",
   "main": "cli.js",
   "repository": "https://github.com/kyle-west/pkgpig",


### PR DESCRIPTION
We were treating moving from a release candidate to a full release like bumping major versions, but that's not the same thing. Things still would have worked fine, but would have skipped versions.

Additionally, adds a _View all versions_ option before committing to changes in the sync CLI 